### PR TITLE
Correcting the URL for JSON-RPC based APIs

### DIFF
--- a/soundex/templates/soundex.html
+++ b/soundex/templates/soundex.html
@@ -90,7 +90,7 @@ $(document).ready(function() {
 
 <ul>
     <li><a href="http://thottingal.in/blog/2009/07/26/indicsoundex/">Read More about the algorithm </a></li>
-    <li><a href="apis.html#soundex">Read about the JSON-RPC based APIs of SILPA for this service </a></li>
+    <li><a href="http://silpa.readthedocs.org/en/latest/apis.html">Read about the JSON-RPC based APIs of SILPA for this service </a></li>
 </ul>
 
 <form id="soundex_form" action="" method="post">


### PR DESCRIPTION
The url for JSON-RPC based APIs of libindic was incorrect.